### PR TITLE
Harden non-Claude provider commit path + neutralize README provider framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,18 +130,23 @@ co-scientist tools list       # show every registered tool the agents can call
 
 ## LLM provider
 
-The agents talk to one LLM provider per session, configured in [`config/default.toml`](config/default.toml) (override with your own `co-scientist.toml`):
+The agents are provider-agnostic — every agent talks to one LLM provider per session, picked in [`config/default.toml`](config/default.toml) (override with your own `co-scientist.toml`). Any of the providers below works; pick whichever you have a key for. Set `provider` and the per-agent `[models]` to your chosen vendor's model ids:
 
 ```toml
 [llm]
-provider = "anthropic"
+provider = "openai"          # or anthropic / openrouter / gemini / groq / together / mistral / ollama / openai_compatible
+
+[models]
+generation = "gpt-5"         # use whatever model ids your provider exposes
+reflection = "gpt-5"
+# ... (see config/default.toml for the full per-agent list)
 ```
 
 | provider              | Endpoint                                                | Required key            | Example models                                            |
 | --------------------- | ------------------------------------------------------- | ----------------------- | --------------------------------------------------------- |
-| `anthropic` *(default)* | api.anthropic.com                                     | `ANTHROPIC_API_KEY`     | `claude-opus-4-7`, `claude-sonnet-4-6`                    |
 | `openai`              | api.openai.com                                          | `OPENAI_API_KEY`        | `gpt-5`, `gpt-4o`, `o3-mini`                              |
-| `openrouter`          | openrouter.ai — 200+ models from every major vendor     | `OPENROUTER_API_KEY`    | `anthropic/claude-3.5-sonnet`, `openai/gpt-5`, `google/gemini-2.5-pro`, `meta-llama/llama-3.3-70b-instruct` |
+| `anthropic`           | api.anthropic.com                                       | `ANTHROPIC_API_KEY`     | `claude-opus-4-7`, `claude-sonnet-4-6`                    |
+| `openrouter`          | openrouter.ai — 200+ models from every major vendor     | `OPENROUTER_API_KEY`    | `openai/gpt-5`, `google/gemini-2.5-pro`, `anthropic/claude-3.5-sonnet`, `meta-llama/llama-3.3-70b-instruct` |
 | `gemini` / `google`   | generativelanguage.googleapis.com (OpenAI-compat)       | `GEMINI_API_KEY`        | `gemini-2.5-pro`, `gemini-2.5-flash`                      |
 | `groq`                | api.groq.com                                            | `GROQ_API_KEY`          | `llama-3.3-70b-versatile`, `mixtral-8x7b-32768`           |
 | `together`            | api.together.xyz                                        | `TOGETHER_API_KEY`      | `meta-llama/Llama-3.3-70B-Instruct-Turbo`                 |
@@ -159,11 +164,13 @@ referer = "https://your-app.example.com"   # optional, for catalog attribution
 title   = "My Co-Scientist"
 
 [models]
-generation         = "anthropic/claude-3.5-sonnet"
-reflection         = "openai/gpt-5"
+generation         = "openai/gpt-5"
+reflection         = "anthropic/claude-3.5-sonnet"
 ranking_pairwise   = "google/gemini-2.5-flash"
-metareview_final   = "anthropic/claude-opus-4-7"
+metareview_final   = "meta-llama/llama-3.3-70b-instruct"
 ```
+
+Any per-agent model can point at any vendor — the example above just mixes four. Use whatever combination you prefer.
 
 Cost is estimated via `co_scientist/llm/routing.py`'s `PRICE_TABLE`; unknown models match a family-hint (flash / mini / opus / sonnet / gemini / llama / mistral) so brand-new previews price sensibly. Tighten `[run] budget_usd` if running on a new model you haven't sanity-checked.
 

--- a/README.md
+++ b/README.md
@@ -130,16 +130,26 @@ co-scientist tools list       # show every registered tool the agents can call
 
 ## LLM provider
 
-The agents are provider-agnostic — every agent talks to one LLM provider per session, picked in [`config/default.toml`](config/default.toml) (override with your own `co-scientist.toml`). Any of the providers below works; pick whichever you have a key for. Set `provider` and the per-agent `[models]` to your chosen vendor's model ids:
+The agents are provider-agnostic — every agent talks to one LLM provider per session, picked in [`config/default.toml`](config/default.toml) (override with your own `co-scientist.toml`). Any of the providers below works; pick whichever you have a key for.
+
+Config is **deep-merged** over [`config/default.toml`](config/default.toml), whose `[models]` defaults are Claude model ids. So if you switch `provider` away from `anthropic`, override **every** key in `[models]` — any key you leave out keeps its Claude default and will be sent to your new provider, which will reject it. A complete OpenAI example:
 
 ```toml
 [llm]
 provider = "openai"          # or anthropic / openrouter / gemini / groq / together / mistral / ollama / openai_compatible
 
 [models]
-generation = "gpt-5"         # use whatever model ids your provider exposes
-reflection = "gpt-5"
-# ... (see config/default.toml for the full per-agent list)
+parse_goal          = "gpt-4o-mini"
+generation          = "gpt-5"
+reflection          = "gpt-5"
+evolution           = "gpt-5"
+ranking_pairwise    = "gpt-4o"
+ranking_debate      = "gpt-4o"
+ranking_priority    = "gpt-5"
+metareview_feedback = "gpt-4o"
+metareview_final    = "gpt-5"
+classifier          = "gpt-4o-mini"
+judge               = "gpt-4o"
 ```
 
 | provider              | Endpoint                                                | Required key            | Example models                                            |

--- a/co_scientist/agents/evolution.py
+++ b/co_scientist/agents/evolution.py
@@ -184,6 +184,7 @@ class EvolutionAgent(BaseAgent):
                 max_iters=self.deps.cfg.tool_loop.evolution_max_iters,
                 parallel_cap=self.deps.cfg.tool_loop.parallel_cap,
                 tool_timeout_s=self.deps.cfg.tool_loop.tool_timeout_seconds,
+                force_terminal_tool="record_hypothesis",
             )
         except ToolLoopExhausted as e:
             log.warning("evolution_tool_loop_exhausted", err=str(e))

--- a/co_scientist/agents/reflection.py
+++ b/co_scientist/agents/reflection.py
@@ -90,6 +90,7 @@ class ReflectionAgent(BaseAgent):
                 max_iters=self.deps.cfg.tool_loop.reflection_max_iters,
                 parallel_cap=self.deps.cfg.tool_loop.parallel_cap,
                 tool_timeout_s=self.deps.cfg.tool_loop.tool_timeout_seconds,
+                force_terminal_tool="record_review",
             )
         except ToolLoopExhausted as e:
             raise RuntimeError(f"reflection exhausted tool loop: {e}") from e

--- a/co_scientist/cli.py
+++ b/co_scientist/cli.py
@@ -219,7 +219,7 @@ def run(
     if est.warning:
         console.print(f"[yellow]{est.warning}[/yellow]")
 
-    prefs = preferences_file.read_text() if preferences_file else None
+    prefs = preferences_file.read_text(encoding="utf-8") if preferences_file else None
     from .agents.supervisor import Supervisor
 
     sup = Supervisor(cfg)
@@ -353,7 +353,7 @@ def report(
     if p is None:
         console.print(f"[red]No final overview yet for {session_id}[/red]")
         raise typer.Exit(1)
-    text = p.read_text()
+    text = p.read_text(encoding="utf-8")
     if format == "json":
         console.print_json(data={"session_id": session_id, "path": str(p), "content": text})
     else:

--- a/co_scientist/storage/artifacts.py
+++ b/co_scientist/storage/artifacts.py
@@ -57,12 +57,12 @@ def session_root(cfg: Config, session_id: str) -> Path:
 def _write(p: Path, payload: Any) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     tmp = p.with_suffix(p.suffix + ".tmp")
-    tmp.write_text(json.dumps(payload, indent=2, default=str, ensure_ascii=False))
+    tmp.write_text(json.dumps(payload, indent=2, default=str, ensure_ascii=False), encoding="utf-8")
     tmp.replace(p)  # atomic on POSIX
 
 
 def _read(p: Path) -> Any:
-    return json.loads(p.read_text())
+    return json.loads(p.read_text(encoding="utf-8"))
 
 
 async def write_json(cfg: Config, session_id: str, kind: str, id_: str, payload: Any) -> str:
@@ -96,7 +96,7 @@ async def write_text(cfg: Config, session_id: str, kind: str, id_: str, suffix: 
     def _do() -> None:
         p.parent.mkdir(parents=True, exist_ok=True)
         tmp = p.with_suffix(p.suffix + ".tmp")
-        tmp.write_text(body)
+        tmp.write_text(body, encoding="utf-8")
         tmp.replace(p)
 
     await asyncio.to_thread(_do)

--- a/co_scientist/web/app.py
+++ b/co_scientist/web/app.py
@@ -168,7 +168,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 raise HTTPException(status_code=404, detail="overview unavailable") from e
             if not path.is_file():
                 raise HTTPException(status_code=404, detail="overview missing on disk")
-            overview_md = path.read_text()
+            overview_md = path.read_text(encoding="utf-8")
             return TEMPLATES.TemplateResponse(
                 request,
                 "overview.html",


### PR DESCRIPTION
## Summary

Follow-up to the closed #1 ("Fix OpenAI/gpt-4o compatibility"). That PR's core idea — forcing models to commit via the recording tool — is already in the codebase in a more robust form (`terminal_tool_names` early-exit + `force_terminal_tool`). This PR applies the two legitimately-missing pieces and makes the README genuinely provider-agnostic.

### Code
- **Wire `force_terminal_tool` into Reflection and Evolution.** It was only on Generation. Non-Claude models (OpenAI/Gemini) sometimes answer in text instead of calling the recording tool; without the last-iteration force they burn the loop and raise `ToolLoopExhausted`. Reflection now forces `record_review`, Evolution forces `record_hypothesis` — matching Generation's `record_hypothesis`.
- **UTF-8 on artifact I/O** (`artifacts.py`). Adopts #1's `encoding="utf-8"` on writes and makes the read symmetric, so non-ASCII model output is safe on platforms whose default encoding isn't UTF-8.

### Docs
- README no longer presents Anthropic as *the recommended / default* provider. The provider section now opens by stating any provider works, the config snippet uses OpenAI, and the multi-vendor example no longer leads with Claude. Factual capability docs (feature-support matrix, bench preset descriptions) are unchanged because they document real per-vendor capability, not a recommendation.

## Testing
- `pytest co_scientist/tests` — **214 passed**.
- `ruff check` on all touched files — clean.
- **End-to-end OpenAI smoke run**: full pipeline (parse_goal → generation → reflection → ranking → metareview) through native OpenAI `gpt-4o-mini`. Result: `status=done`, ~$0.02, 2 hypotheses, 16 ranking matches, **zero tool-loop exhaustions / tracebacks**. Reflection (the newly-forced agent) ran 5 transcripts with no exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
