### PR TITLE
fix: use sys.executable for science-skill .py runner

### DIFF
--- a/co_scientist/tools/science_skills.py
+++ b/co_scientist/tools/science_skills.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -178,7 +179,7 @@ class ScienceSkillTool:
 
         cmd: list[str]
         if entry.suffix == ".py":
-            cmd = ["python", str(entry)]
+            cmd = [sys.executable, str(entry)]
         elif entry.suffix in (".sh", ""):
             cmd = ["bash", str(entry)]
         else:


### PR DESCRIPTION
## Problem
The science-skill runner exec'd a literal `python` binary (`cmd = ["python", str(entry)]`), which is absent on systems that only ship `python3` (modern macOS, many Linux distros). This produces `FileNotFoundError: No such file or directory: 'python'` at skill-run time.

This is a pre-existing latent bug on `main` — it was surfaced by the new science-skill tests proposed in #4, which fail on any machine without a `python` shim on PATH.

## Fix
Use `sys.executable` so `.py` skills run with the same interpreter that launched the app.

## Validation
- `ruff check`: passed
- Full unit suite on this branch: **214 passed**
- Verified the 6 science-skill tests from #4 pass once the interpreter resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)