### PR TITLE
ci: run unit tests on PRs to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install package + dev deps
+        run: pip install -e ".[dev]"
+      - name: Run unit tests
+        run: pytest co_scientist/tests/unit -q


### PR DESCRIPTION
Adds a minimal GitHub Actions workflow (`tests`) that runs the unit suite on pull requests and pushes to `main`.

- Python 3.12, installs `-e ".[dev]"`, runs `pytest co_scientist/tests/unit -q`
- **Tests only** — no lint gate (ruff stays local)
- Pairs with the new `main` branch ruleset; once this lands, the `test` check can be marked required so broken PRs are caught automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)