### PR TITLE
fix: resolve two OpenAI API incompatibilities (stop_sequences + max_completion_tokens)

### DIFF
--- a/co_scientist/agents/ranking.py
+++ b/co_scientist/agents/ranking.py
@@ -343,7 +343,7 @@ class RankingAgent(BaseAgent):
             tools=[],
             tool_choice=None,
             max_output_tokens=2048,
-            stop_sequences=["\n\n\n"],
+            stop_sequences=None,
         )
         ctx = CallContext(
             session_id=session.id, task_id=None,

--- a/co_scientist/llm/openai_client.py
+++ b/co_scientist/llm/openai_client.py
@@ -309,7 +309,7 @@ def _build_openai_request(spec: AgentCallSpec) -> dict[str, Any]:
     request: dict[str, Any] = {
         "model": spec.route.model,
         "messages": messages,
-        "max_tokens": spec.max_output_tokens,
+        "max_completion_tokens": spec.max_output_tokens,
     }
     if spec.stop_sequences:
         request["stop"] = spec.stop_sequences
@@ -441,7 +441,7 @@ _STOP_REASON_MAP = {
     "stop": "end_turn",
     "tool_calls": "tool_use",
     "function_call": "tool_use",  # legacy
-    "length": "max_tokens",
+    "length": "max_completion_tokens",
     "content_filter": "refusal",
 }
 


### PR DESCRIPTION
## Problem

Two bugs prevent the pipeline from running correctly when `provider = "openai"` is set:

### 1. `ranking.py` — invalid `stop_sequences` value

`AgentCallSpec` was constructed with `stop_sequences=["\n\n\n"]` (an all-whitespace string). Both the Anthropic and OpenAI APIs reject this, causing every pairwise ranking call to fail with a 400 Bad Request. The stop sequence was not meaningful to the ranking logic, so the fix is to pass `None` and let the model finish naturally.

### 2. `openai_client.py` — `max_tokens` deprecated for gpt-5.x

The Chat Completions API deprecated `max_tokens` in favour of `max_completion_tokens` for current GPT-5.x models. Sending the old field name causes a 400 Bad Request. The `_STOP_REASON_MAP` `"length"` key is updated to match the new field name for consistent finish-reason handling.

## Changes

- `co_scientist/agents/ranking.py` L346: `stop_sequences=None`
- `co_scientist/llm/openai_client.py` L312: `"max_completion_tokens"` in the request dict
- `co_scientist/llm/openai_client.py` L444: `"length": "max_completion_tokens"` in `_STOP_REASON_MAP`

## Testing

Validated by running full end-to-end sessions with `provider = "openai"` and `gpt-5.4-nano`/`gpt-5.4-mini`/`gpt-5.5` models — tournament completed with correct Elo rankings and no 400 errors.

Made with [Cursor](https://cursor.com)