### PR TITLE
Deep-run termination guards + config-driven evolution gate + OpenAI API fixes

### DIFF
--- a/co_scientist/agents/ranking.py
+++ b/co_scientist/agents/ranking.py
@@ -343,7 +343,7 @@ class RankingAgent(BaseAgent):
             tools=[],
             tool_choice=None,
             max_output_tokens=2048,
-            stop_sequences=["\n\n\n"],
+            stop_sequences=None,
         )
         ctx = CallContext(
             session_id=session.id, task_id=None,

--- a/co_scientist/agents/supervisor.py
+++ b/co_scientist/agents/supervisor.py
@@ -142,6 +142,8 @@ class Supervisor:
                 k=self.cfg.termination.elo_stability_k,
                 n=self.cfg.termination.elo_stability_n,
                 eps=self.cfg.termination.elo_stability_eps,
+                min_ideas=self.cfg.termination.min_ideas_before_stable,
+                min_matches=self.cfg.termination.min_matches_before_stable,
             )
 
             stop_reason = await self._main_loop(conn, deps, session, tracker)
@@ -445,15 +447,19 @@ class Supervisor:
             ))
             enqueued += 1
 
-        # If the leaderboard has matured (>= 20 hypotheses with ≥ 3 matches), evolve.
+        # If the leaderboard has matured, evolve. The maturity gate and top_k are
+        # config-driven so deep runs can lower the gate to grow the pool faster.
         mature = sum(1 for h in in_tournament if h.matches_played >= 3)
-        if mature >= 20:
+        if mature >= self.cfg.evolution.min_mature:
             await task_repo.enqueue(conn, Task(
                 id=ids.task_id(), session_id=session.id,
                 created_at=datetime.now(UTC),
                 agent="evolution", action="EvolveTopHypotheses",
                 target_id=None,
-                payload={"top_k": 5, "strategies": ["combine", "simplify", "out_of_box"]},
+                payload={
+                    "top_k": self.cfg.evolution.top_k,
+                    "strategies": ["combine", "simplify", "out_of_box"],
+                },
                 priority=140, status="pending",
                 idempotency_key=f"{session.id}::evolution::idle::{anchor_mc}",
             ))

--- a/co_scientist/config.py
+++ b/co_scientist/config.py
@@ -67,6 +67,20 @@ class TerminationCfg(BaseModel):
     elo_stability_n: int = 3
     elo_stability_eps: float = 25.0
     match_snapshot_every: int = 10
+    # Guards that prevent elo_stable from firing on a small pool.
+    # Defaults of 0 preserve the original behaviour.
+    min_ideas_before_stable: int = 0
+    min_matches_before_stable: int = 0
+
+
+class EvolutionCfg(BaseModel):
+    """Controls when the idle-refinement loop triggers evolution."""
+    # Minimum number of *mature* hypotheses (>= 3 matches played) required
+    # before the supervisor schedules an EvolveTopHypotheses task.
+    # Default matches the original hardcoded value.
+    min_mature: int = 20
+    # How many top hypotheses to evolve per idle pass.
+    top_k: int = 5
 
 
 class BudgetSharesCfg(BaseModel):
@@ -258,6 +272,7 @@ class Config(BaseModel):
     vectors: VectorsCfg = Field(default_factory=VectorsCfg)
     ranking: RankingCfg = Field(default_factory=RankingCfg)
     termination: TerminationCfg = Field(default_factory=TerminationCfg)
+    evolution: EvolutionCfg = Field(default_factory=EvolutionCfg)
     budget_shares: BudgetSharesCfg = Field(default_factory=BudgetSharesCfg)
     models: ModelsCfg = Field(default_factory=ModelsCfg)
     thinking: ThinkingCfg = Field(default_factory=ThinkingCfg)

--- a/co_scientist/llm/openai_client.py
+++ b/co_scientist/llm/openai_client.py
@@ -309,7 +309,7 @@ def _build_openai_request(spec: AgentCallSpec) -> dict[str, Any]:
     request: dict[str, Any] = {
         "model": spec.route.model,
         "messages": messages,
-        "max_tokens": spec.max_output_tokens,
+        "max_completion_tokens": spec.max_output_tokens,
     }
     if spec.stop_sequences:
         request["stop"] = spec.stop_sequences
@@ -441,7 +441,7 @@ _STOP_REASON_MAP = {
     "stop": "end_turn",
     "tool_calls": "tool_use",
     "function_call": "tool_use",  # legacy
-    "length": "max_tokens",
+    "length": "max_completion_tokens",
     "content_filter": "refusal",
 }
 

--- a/co_scientist/llm/openai_client.py
+++ b/co_scientist/llm/openai_client.py
@@ -441,7 +441,10 @@ _STOP_REASON_MAP = {
     "stop": "end_turn",
     "tool_calls": "tool_use",
     "function_call": "tool_use",  # legacy
-    "length": "max_completion_tokens",
+    # Values are normalized to Anthropic's stop_reason vocabulary, not the
+    # OpenAI request field name — keep "max_tokens" (see _build_openai_request
+    # which separately sends the "max_completion_tokens" request field).
+    "length": "max_tokens",
     "content_filter": "refusal",
 }
 

--- a/co_scientist/orchestrator/termination.py
+++ b/co_scientist/orchestrator/termination.py
@@ -34,15 +34,25 @@ class EloSnapshot:
     match_count: int
     top_ids: tuple[str, ...]
     top_elos: tuple[float, ...]
+    pool_size: int = 0  # total hypotheses in_tournament or pinned at snapshot time
 
 
 class StabilityTracker:
     """Owns the recent EloSnapshot history. One per session."""
 
-    def __init__(self, k: int, n: int, eps: float) -> None:
+    def __init__(
+        self,
+        k: int,
+        n: int,
+        eps: float,
+        min_ideas: int = 0,
+        min_matches: int = 0,
+    ) -> None:
         self.k = k
         self.n = n
         self.eps = eps
+        self.min_ideas = min_ideas
+        self.min_matches = min_matches
         self._history: list[EloSnapshot] = []
 
     def push(self, snap: EloSnapshot) -> None:
@@ -59,6 +69,13 @@ class StabilityTracker:
         if len(self._history) < self.n:
             return False
         recent = self._history[-self.n :]
+        # Guard: do not declare stability until the pool is large enough
+        # and enough matches have been played.  Guards default to 0 (off),
+        # preserving the original behaviour when not configured.
+        if self.min_ideas > 0 and recent[-1].pool_size < self.min_ideas:
+            return False
+        if self.min_matches > 0 and recent[-1].match_count < self.min_matches:
+            return False
         # All N snapshots must have the same top-K id set
         first_set = set(recent[0].top_ids)
         for s in recent[1:]:
@@ -76,7 +93,7 @@ class StabilityTracker:
 async def snapshot_top_k(
     conn: aiosqlite.Connection, session_id: str, k: int
 ) -> EloSnapshot:
-    """Read the current top-K leaderboard + count of completed matches."""
+    """Read the current top-K leaderboard + count of completed matches + pool size."""
     async with conn.execute(
         """SELECT id, elo FROM hypotheses
               WHERE session_id=? AND state IN ('in_tournament','pinned')
@@ -90,10 +107,17 @@ async def snapshot_top_k(
         (session_id,),
     ) as cur:
         mc_row = await cur.fetchone()
+    async with conn.execute(
+        """SELECT COUNT(*) AS n FROM hypotheses
+              WHERE session_id=? AND state IN ('in_tournament','pinned')""",
+        (session_id,),
+    ) as cur:
+        pool_row = await cur.fetchone()
     return EloSnapshot(
         match_count=mc_row["n"] if mc_row else 0,
         top_ids=tuple(r["id"] for r in rows),
         top_elos=tuple(r["elo"] for r in rows),
+        pool_size=pool_row["n"] if pool_row else 0,
     )
 
 
@@ -126,7 +150,7 @@ def should_stop(
         return StopReason.BUDGET
     if wall_clock_exceeded(session):
         return StopReason.WALL_CLOCK
-    _ = cfg
+    del cfg  # reserved for future config-driven termination rules
     if tracker.is_stable():
         return StopReason.ELO_STABLE
     return None

--- a/co_scientist/tests/unit/test_provider.py
+++ b/co_scientist/tests/unit/test_provider.py
@@ -217,7 +217,7 @@ def test_build_request_emits_system_and_user_messages() -> None:
     )
     req = _build_openai_request(spec)
     assert req["model"] == "gpt-5"
-    assert req["max_tokens"] == 512
+    assert req["max_completion_tokens"] == 512
     roles = [m["role"] for m in req["messages"]]
     assert roles == ["system", "user"]
     # cache_control must NOT leak into the OpenAI request

--- a/co_scientist/tests/unit/test_termination.py
+++ b/co_scientist/tests/unit/test_termination.py
@@ -61,9 +61,17 @@ def test_external_stop_wins_over_progress() -> None:
 
 # ----------------------------- stability tracker ----------------------------- #
 
-def _snap(match_count: int, ids: list[str], elos: list[float]) -> EloSnapshot:
+def _snap(
+    match_count: int,
+    ids: list[str],
+    elos: list[float],
+    pool_size: int = 0,
+) -> EloSnapshot:
     return EloSnapshot(
-        match_count=match_count, top_ids=tuple(ids), top_elos=tuple(elos),
+        match_count=match_count,
+        top_ids=tuple(ids),
+        top_elos=tuple(elos),
+        pool_size=pool_size,
     )
 
 
@@ -121,3 +129,67 @@ def test_should_stop_none_when_running() -> None:
     tr = StabilityTracker(k=3, n=3, eps=25)
     s = _session(used_usd=1, budget_usd=10, deadline_in_s=60)
     assert should_stop(cfg, s, tr) is None
+
+
+# ----------------------------- min_ideas guard ----------------------------- #
+
+def test_min_ideas_guard_blocks_stable_on_small_pool() -> None:
+    """elo_stable must not fire when pool_size < min_ideas."""
+    tr = StabilityTracker(k=3, n=3, eps=25, min_ideas=10)
+    for mc in (10, 20, 30):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=3))
+    assert not tr.is_stable()
+
+
+def test_min_ideas_guard_allows_stable_once_pool_is_large_enough() -> None:
+    tr = StabilityTracker(k=3, n=3, eps=25, min_ideas=3)
+    for mc in (10, 20, 30):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=3))
+    assert tr.is_stable()
+
+
+def test_min_ideas_guard_zero_is_disabled() -> None:
+    """Default min_ideas=0 must never block stability (backward compat)."""
+    tr = StabilityTracker(k=3, n=3, eps=25, min_ideas=0)
+    for mc in (10, 20, 30):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=1))
+    assert tr.is_stable()
+
+
+# ----------------------------- min_matches guard ----------------------------- #
+
+def test_min_matches_guard_blocks_stable_below_threshold() -> None:
+    """elo_stable must not fire when total match_count < min_matches."""
+    tr = StabilityTracker(k=3, n=3, eps=25, min_matches=100)
+    for mc in (10, 20, 30):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=20))
+    assert not tr.is_stable()
+
+
+def test_min_matches_guard_allows_stable_once_enough_matches() -> None:
+    tr = StabilityTracker(k=3, n=3, eps=25, min_matches=30)
+    for mc in (10, 20, 30):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=20))
+    assert tr.is_stable()
+
+
+def test_min_matches_guard_zero_is_disabled() -> None:
+    tr = StabilityTracker(k=3, n=3, eps=25, min_matches=0)
+    for mc in (10, 20, 30):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=1))
+    assert tr.is_stable()
+
+
+# ----------------------------- combined guards ----------------------------- #
+
+def test_both_guards_must_pass_for_stability() -> None:
+    """Stable only when both min_ideas AND min_matches are satisfied."""
+    tr = StabilityTracker(k=3, n=3, eps=25, min_ideas=10, min_matches=100)
+    # pool_size OK but matches too low → not stable
+    for mc in (10, 20, 30):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=15))
+    assert not tr.is_stable()
+    # Now push with both satisfied
+    for mc in (110, 120, 130):
+        tr.push(_snap(mc, ["a", "b", "c"], [1500, 1400, 1300], pool_size=15))
+    assert tr.is_stable()

--- a/config/default.toml
+++ b/config/default.toml
@@ -45,6 +45,19 @@ elo_stability_k = 5                  # top-K tracked
 elo_stability_n = 3                  # snapshots compared
 elo_stability_eps = 25.0
 match_snapshot_every = 10
+# Guards: elo_stable cannot fire until these thresholds are met.
+# Default 0 = disabled (preserves original behaviour).
+# Deep runs should set min_ideas_before_stable >= max_ideas / 2.
+min_ideas_before_stable = 0
+min_matches_before_stable = 0
+
+[evolution]
+# Minimum number of *mature* hypotheses (>= 3 matches played) before the
+# supervisor schedules an evolution pass.  Lower this for deep runs where
+# the pool size is larger than the default 60-idea session.
+min_mature = 20
+# How many top hypotheses to evolve per idle pass.
+top_k = 5
 
 [budget_shares]
 generation = 0.20


### PR DESCRIPTION
## Summary

This consolidates **#10** and **#9** (which were stacked — #10 already contained all of #9) and **corrects one regression** they shared. All changes are backward-compatible; defaults preserve existing behaviour.

Credit for the feature work goes to @idanzinner-OMGene — the first two commits here are theirs, applied unchanged. The third commit is the fix described below.

## What's included

### 1. Deep-run termination guards (from #10)
`elo_stable` could fire on a tiny pool (~3 hypotheses) before most generators finished, ending sessions after only 2–3 hypotheses with slow frontier models.

- `TerminationCfg`: new `min_ideas_before_stable` / `min_matches_before_stable` (default `0` = disabled).
- `EloSnapshot` gains `pool_size`; `snapshot_top_k` populates it via `COUNT(*)`.
- `StabilityTracker.is_stable()` will not declare stability until both thresholds are met.

### 2. Config-driven evolution gate (from #10)
The evolution gate was hardcoded at `mature >= 20`, structurally unreachable for small `--n`.

- New `[evolution]` config section: `min_mature` (default `20`) and `top_k` (default `5`), replacing the hardcoded values in `supervisor._decide_next_steps`.

### 3. OpenAI API fixes (from #9)
- `ranking.py`: `stop_sequences=None` (the previous all-whitespace `["\n\n\n"]` was rejected by both APIs).
- `openai_client.py`: request field `max_tokens` → `max_completion_tokens` (required by current GPT-5.x Chat Completions).

## Correction made in this PR

#9/#10 also changed `_STOP_REASON_MAP`'s `"length"` entry from `"max_tokens"` to `"max_completion_tokens"`. That map normalizes OpenAI's `finish_reason` into **Anthropic's `stop_reason` vocabulary** — the value must stay `"max_tokens"`:

- `bench/runner.py` checks `stop == "max_tokens"`,
- the Anthropic client emits `"max_tokens"`, so the OpenAI adapter must match for cross-provider consistency.

As shipped, #9 and #10 were **CI-red** — they broke two existing tests (`test_adapt_response_length_finish_maps_to_max_tokens` and `test_build_request_emits_system_and_user_messages`). This PR:
- reverts the `_STOP_REASON_MAP` value to `"max_tokens"` (keeping the correct `max_completion_tokens` request field), and
- updates the stale `test_build_request_emits_system_and_user_messages` assertion.

## Testing

- `pytest co_scientist/tests/unit`: **221 passed**
- `ruff check co_scientist`: clean
- Verified the shipped `config/default.toml` round-trips through `load_config()` and that the guards behave correctly (pool of 3 → not stable; pool of 25 with ≥200 matches → stable).

Supersedes #9 and #10.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw7irkUY85J15oo1gkSesF)_