### PR TITLE
fix(llm): preserve Gemini thought signatures across tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Providers are listed alphabetically — none is preferred; pick whichever you ha
 | provider              | Endpoint                                                | API-key env var         | Example models                                            |
 | --------------------- | ------------------------------------------------------- | ----------------------- | --------------------------------------------------------- |
 | `anthropic`           | api.anthropic.com                                       | `ANTHROPIC_API_KEY`     | `claude-opus-4-7`, `claude-sonnet-4-6`                    |
-| `gemini` / `google`   | generativelanguage.googleapis.com (OpenAI-compat)       | `GEMINI_API_KEY`        | `gemini-2.5-pro`, `gemini-2.5-flash`                      |
+| `gemini` / `google`   | generativelanguage.googleapis.com (OpenAI-compat)       | `GEMINI_API_KEY`        | `gemini-3.5-flash-lite`, `gemini-3.5-flash`, `gemini-2.5-pro` |
 | `groq`                | api.groq.com                                            | `GROQ_API_KEY`          | `llama-3.3-70b-versatile`, `mixtral-8x7b-32768`           |
 | `mistral`             | api.mistral.ai                                          | `MISTRAL_API_KEY`       | `mistral-large-latest`, `codestral-latest`                |
 | `ollama`              | localhost:11434 — local models                          | *(none)*                | `llama3.3:70b`, `qwen2.5:32b`                             |
@@ -171,6 +171,39 @@ Providers are listed alphabetically — none is preferred; pick whichever you ha
 | `together`            | api.together.xyz                                        | `TOGETHER_API_KEY`      | `meta-llama/Llama-3.3-70B-Instruct-Turbo`                 |
 
 > Key precedence: for every OpenAI-compatible preset (`openrouter`, `gemini`, `groq`, `together`, `mistral`, `ollama`), `OPENAI_API_KEY` is used **first** if it's set, and the provider-specific var above is only the fallback. So if you have a stray `OPENAI_API_KEY` in your environment it will be sent to the preset's endpoint (and rejected) — unset it, or set only the provider's own key, when using a preset.
+
+### Gemini thinking and tool calls
+
+Gemini 3 models attach an opaque thought signature to function calls. The
+OpenAI-compatible adapter preserves provider-owned tool-call metadata, but
+only the named `gemini` / `google` providers replay Gemini's documented
+`extra_content` envelope with the corresponding function result. Other
+response-only tool-call fields are retained for diagnostics and future
+provider adapters, but are not sent to endpoints that may reject them. No
+manual signature configuration is required.
+
+Gemini's thinking level is also optional. With `thinking_level = "default"`
+the request omits `reasoning_effort` and Gemini uses the selected model's
+default. For this system's autonomous, multi-step literature and evaluation
+work, `medium` is a sensible starting point:
+
+```toml
+[llm]
+provider = "gemini"
+
+[llm.gemini]
+thinking_level = "medium"  # default | minimal | low | medium | high
+
+[llm.gemini.thinking_by_mode]
+"parse_goal" = "minimal"
+"reflection.verification" = "high"
+"metareview.final" = "high"
+```
+
+Per-mode entries override the global level and use the same `agent.mode` names
+as model routing. These semantic levels are separate from the numeric
+Anthropic `[thinking]` token budgets. Do not fabricate or edit thought
+signatures; the adapter treats them as provider-owned continuation state.
 
 Mixing vendors per session requires picking the provider once; for multi-vendor routing in a single session, use `provider = "openrouter"` and let OpenRouter dispatch upstream per model:
 
@@ -197,11 +230,11 @@ Cost is estimated via `co_scientist/llm/routing.py`'s `PRICE_TABLE`; unknown mod
 | Feature                     | `anthropic` | everything else (OpenAI + all OpenAI-compatible providers) |
 | --------------------------- | ----------- | ---------------------------------------------------------- |
 | Tool / function call *(required)* | ✅    | ✅ native OpenAI; on other endpoints it must be supported or the run fails |
-| Extended reasoning          | ✅ via `thinking` budgets | ✅ via `reasoning_effort`, **only for reasoning models** — the model id must start with `o1`/`o3`/`o4` or contain `reasoning`; for any other model (e.g. `gpt-4o`) the thinking budget is dropped |
+| Extended reasoning          | ✅ via numeric `[thinking]` budgets | ✅ OpenAI reasoning models use `reasoning_effort`; Gemini uses optional `[llm.gemini]` semantic levels |
 | Prompt-cache breakpoints    | ✅          | ❌ (stripped before sending)                               |
 | Batch API (50%-off ranking) | ✅          | ❌ (Anthropic-only; other providers run all matches synchronously) |
 
-> Note: the reasoning-model check is a name heuristic ([`openai_client.py`](co_scientist/llm/openai_client.py) `_is_reasoning_model`). Newer reasoning-capable models whose ids don't match the pattern (e.g. `gpt-5`) won't get `reasoning_effort` until the heuristic is updated — they still work, just without an explicit reasoning budget.
+> For direct OpenAI and generic OpenAI-compatible endpoints, the reasoning-model check is a name heuristic ([`openai_client.py`](co_scientist/llm/openai_client.py) `_is_reasoning_model`). Model ids that do not match it still work, but do not receive a numeric `[thinking]` budget translated to `reasoning_effort`. The named Gemini provider uses its explicit semantic configuration instead.
 
 ## Configuration
 

--- a/co_scientist/config.py
+++ b/co_scientist/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -209,6 +209,21 @@ class OpenRouterProviderCfg(BaseModel):
     title: str = ""
 
 
+ThinkingLevel = Literal["default", "minimal", "low", "medium", "high"]
+
+
+class GeminiProviderCfg(BaseModel):
+    """Gemini reasoning controls for the OpenAI-compatible endpoint.
+
+    ``default`` omits ``reasoning_effort`` and lets the selected Gemini model
+    use its own default. Per-mode overrides use routing keys such as
+    ``generation.literature`` or ``metareview.final``.
+    """
+
+    thinking_level: ThinkingLevel = "default"
+    thinking_by_mode: dict[str, ThinkingLevel] = Field(default_factory=dict)
+
+
 class LLMCfg(BaseModel):
     """Choose which LLM vendor backs the agents.
 
@@ -223,8 +238,9 @@ class LLMCfg(BaseModel):
       major vendor in one place. Set OPENROUTER_API_KEY (or
       OPENAI_API_KEY). Optional attribution in [llm.openrouter].
     - "gemini" / "google" — Google Gemini via the official OpenAI-compat
-      endpoint. Set GEMINI_API_KEY. Models: "gemini-2.5-pro",
-      "gemini-2.5-flash", etc.
+      endpoint. Set GEMINI_API_KEY. Thought signatures are preserved
+      automatically. Optional semantic reasoning levels are configured under
+      `llm.gemini`.
     - "groq", "together", "mistral", "ollama" — convenience presets for
       those endpoints; each reads its own API key env var
       (GROQ_API_KEY, TOGETHER_API_KEY, MISTRAL_API_KEY).
@@ -237,6 +253,7 @@ class LLMCfg(BaseModel):
     openai: OpenAIProviderCfg = Field(default_factory=OpenAIProviderCfg)
     anthropic: AnthropicProviderCfg = Field(default_factory=AnthropicProviderCfg)
     openrouter: OpenRouterProviderCfg = Field(default_factory=OpenRouterProviderCfg)
+    gemini: GeminiProviderCfg = Field(default_factory=GeminiProviderCfg)
 
 
 class WebUICfg(BaseModel):

--- a/co_scientist/llm/openai_client.py
+++ b/co_scientist/llm/openai_client.py
@@ -15,6 +15,11 @@ Caveats (intentional gaps vs. AnthropicClient):
 - cache_control breakpoints are stripped — only Anthropic supports them.
 - Thinking budgets are translated to `reasoning_effort` when the model name
   starts with "o" (o1/o3/o4 family); else dropped.
+- Gemini thinking levels can be configured explicitly; otherwise the model's
+  provider default is used.
+- Provider-owned tool-call fields are retained as opaque response metadata.
+  Outbound replay is provider-aware; Gemini's documented `extra_content`
+  thought-signature envelope is replayed, while other extensions are not.
 - The Anthropic Batch API has no OpenAI analogue here; BatchPool still
   routes through Anthropic.
 - `tool_result.is_error` is encoded into the tool message content; OpenAI
@@ -49,6 +54,17 @@ from .budgets import TokenBudget
 from .retry import RetryPolicy, with_retry
 from .routing import estimate_cost_usd
 
+_CANONICAL_TOOL_CALL_FIELDS = frozenset({"id", "type", "function"})
+_NO_TOOL_CALL_REPLAY_FIELDS: frozenset[str] = frozenset()
+
+# Response schemas are often broader than request schemas. Keep provider
+# metadata losslessly in normalized history, but only replay fields documented
+# as valid request input for the configured endpoint.
+_TOOL_CALL_REPLAY_FIELDS_BY_PROVIDER: dict[str, frozenset[str]] = {
+    "gemini": frozenset({"extra_content"}),
+    "google": frozenset({"extra_content"}),
+}
+
 # --------------------------------------------------------------------------- #
 # Adapter types that quack like anthropic.types.Message / content blocks
 
@@ -61,6 +77,10 @@ class _Block:
     id: str = ""
     name: str = ""
     input: dict[str, Any] = field(default_factory=dict)
+    # Opaque fields returned alongside an OpenAI-compatible tool call. They
+    # survive normalization unchanged, but the request adapter decides which
+    # fields are safe to replay for its configured provider.
+    provider_fields: dict[str, Any] = field(default_factory=dict)
     signature: str = ""
     data: str = ""
     thinking: str = ""
@@ -116,6 +136,7 @@ class OpenAIClient:
         budget: TokenBudget,
         retry_policy: RetryPolicy | None = None,
         compat_mode: bool = False,
+        provider_name: str | None = None,
         preset_base_url: str | None = None,
         preset_api_key_env: str | None = None,
         default_headers: dict[str, str] | None = None,
@@ -148,6 +169,9 @@ class OpenAIClient:
             cap_ms=cfg.retry.cap_ms,
         )
         self._compat_mode = compat_mode or preset_base_url is not None
+        self._provider_name = provider_name or (
+            "openai_compatible" if self._compat_mode else "openai"
+        )
 
         # API key resolution precedence:
         #   1. explicit OPENAI_API_KEY (cfg.secrets or env)
@@ -194,7 +218,18 @@ class OpenAIClient:
         *,
         est_input_tokens: int | None = None,
     ) -> AnthropicResponse:
-        request = _build_openai_request(spec)
+        is_gemini = self._provider_name in ("gemini", "google")
+        reasoning_effort = (
+            _gemini_reasoning_effort(self._cfg, spec) if is_gemini else None
+        )
+        request = _build_openai_request(
+            spec,
+            reasoning_effort=reasoning_effort,
+            translate_thinking_tokens=not is_gemini,
+            tool_call_replay_fields=_TOOL_CALL_REPLAY_FIELDS_BY_PROVIDER.get(
+                self._provider_name, _NO_TOOL_CALL_REPLAY_FIELDS
+            ),
+        )
 
         # Estimate + admit (same accounting as AnthropicClient).
         est_in = est_input_tokens or _rough_token_count(spec)
@@ -243,7 +278,7 @@ class OpenAIClient:
 
         trn_id = transcript_id()
         artifact = {
-            "provider": "openai_compatible" if self._compat_mode else "openai",
+            "provider": self._provider_name,
             "request": _redact(request),
             "response": message.model_dump(),
             "started_at": started.isoformat(),
@@ -287,7 +322,13 @@ class OpenAIClient:
 # --------------------------------------------------------------------------- #
 # Request translation: AgentCallSpec → OpenAI Chat Completions
 
-def _build_openai_request(spec: AgentCallSpec) -> dict[str, Any]:
+def _build_openai_request(
+    spec: AgentCallSpec,
+    *,
+    reasoning_effort: str | None = None,
+    translate_thinking_tokens: bool = True,
+    tool_call_replay_fields: frozenset[str] = _NO_TOOL_CALL_REPLAY_FIELDS,
+) -> dict[str, Any]:
     """Translate normalized spec to OpenAI's chat.completions request."""
     messages: list[dict[str, Any]] = []
 
@@ -304,7 +345,12 @@ def _build_openai_request(spec: AgentCallSpec) -> dict[str, Any]:
 
     # extra_messages comes from the tool loop in Anthropic shape; translate.
     for m in spec.extra_messages:
-        messages.extend(_translate_anthropic_message(m))
+        messages.extend(
+            _translate_anthropic_message(
+                m,
+                tool_call_replay_fields=tool_call_replay_fields,
+            )
+        )
 
     request: dict[str, Any] = {
         "model": spec.route.model,
@@ -346,15 +392,25 @@ def _build_openai_request(spec: AgentCallSpec) -> dict[str, Any]:
         elif kind == "none":
             request["tool_choice"] = "none"
 
-    # Extended-reasoning translation. The o-series models accept
-    # `reasoning_effort` ∈ {minimal, low, medium, high}; map from token budget.
-    if spec.route.thinking_tokens > 0 and _is_reasoning_model(spec.route.model):
+    # An explicit provider semantic level wins. Otherwise, reasoning-capable
+    # OpenAI models receive a level translated from the legacy token budget.
+    if reasoning_effort is not None:
+        request["reasoning_effort"] = reasoning_effort
+    elif (
+        translate_thinking_tokens
+        and spec.route.thinking_tokens > 0
+        and _is_reasoning_model(spec.route.model)
+    ):
         request["reasoning_effort"] = _budget_to_effort(spec.route.thinking_tokens)
 
     return request
 
 
-def _translate_anthropic_message(m: dict[str, Any]) -> list[dict[str, Any]]:
+def _translate_anthropic_message(
+    m: dict[str, Any],
+    *,
+    tool_call_replay_fields: frozenset[str] = _NO_TOOL_CALL_REPLAY_FIELDS,
+) -> list[dict[str, Any]]:
     """Translate one Anthropic-shaped message dict to OpenAI message(s).
 
     Anthropic assistant messages can contain mixed content blocks (text,
@@ -382,7 +438,19 @@ def _translate_anthropic_message(m: dict[str, Any]) -> list[dict[str, Any]]:
             elif btype == "tool_use":
                 args = block.get("input", {})
                 args_str = json.dumps(args, default=str, ensure_ascii=False)
-                tool_calls.append({
+                provider_fields = block.get("provider_fields", {})
+                tool_call: dict[str, Any] = {}
+                if isinstance(provider_fields, dict):
+                    # A response may contain output-only extensions that a
+                    # strict endpoint rejects on input. Replay only fields
+                    # explicitly allowed for this configured provider.
+                    tool_call.update(
+                        _provider_fields_for_replay(
+                            provider_fields,
+                            allowed_fields=tool_call_replay_fields,
+                        )
+                    )
+                tool_call.update({
                     "id": block.get("id") or f"call_{uuid.uuid4().hex[:12]}",
                     "type": "function",
                     "function": {
@@ -390,6 +458,7 @@ def _translate_anthropic_message(m: dict[str, Any]) -> list[dict[str, Any]]:
                         "arguments": args_str,
                     },
                 })
+                tool_calls.append(tool_call)
         msg: dict[str, Any] = {"role": "assistant"}
         if text_parts:
             msg["content"] = "\n".join(text_parts)
@@ -448,7 +517,6 @@ _STOP_REASON_MAP = {
     "content_filter": "refusal",
 }
 
-
 def _adapt_response(raw: Any, model: str) -> _Message:
     choice = raw.choices[0] if raw.choices else None
     finish = (getattr(choice, "finish_reason", None) or "stop") if choice else "stop"
@@ -476,6 +544,7 @@ def _adapt_response(raw: Any, model: str) -> _Message:
                 id=getattr(tc, "id", "") or f"call_{uuid.uuid4().hex[:12]}",
                 name=name,
                 input=args_obj,
+                provider_fields=_provider_fields_from_tool_call(tc),
             ))
 
     usage_obj = getattr(raw, "usage", None)
@@ -501,6 +570,68 @@ def _adapt_response(raw: Any, model: str) -> _Message:
 
 # --------------------------------------------------------------------------- #
 # Heuristics
+
+def _provider_fields_for_replay(
+    provider_fields: dict[str, Any],
+    *,
+    allowed_fields: frozenset[str],
+) -> dict[str, Any]:
+    """Filter opaque response metadata down to valid request extensions."""
+    replayable: dict[str, Any] = {}
+    for key in allowed_fields:
+        if key in _CANONICAL_TOOL_CALL_FIELDS or key not in provider_fields:
+            continue
+        value = provider_fields[key]
+        # Google's documented extra_content envelope is a non-empty object.
+        # Do not replay malformed response metadata into a strict endpoint.
+        if key == "extra_content" and (not isinstance(value, dict) or not value):
+            continue
+        replayable[key] = value
+    return replayable
+
+
+def _provider_fields_from_tool_call(tool_call: Any) -> dict[str, Any]:
+    """Retain nonstandard response fields without interpreting them.
+
+    Prefer the SDK's serialized form, then merge Pydantic extras explicitly
+    because SDK versions differ in how unknown fields are exposed. Retention
+    does not imply replay: request translation applies a provider allowlist.
+    """
+    dumped: dict[str, Any] = {}
+    model_dump = getattr(tool_call, "model_dump", None)
+    if callable(model_dump):
+        candidate = model_dump()
+        if isinstance(candidate, dict):
+            dumped.update(candidate)
+    elif isinstance(tool_call, dict):
+        dumped.update(tool_call)
+    else:
+        raw_fields = getattr(tool_call, "__dict__", None)
+        if isinstance(raw_fields, dict):
+            dumped.update(raw_fields)
+
+    model_extra = getattr(tool_call, "model_extra", None)
+    if isinstance(model_extra, dict):
+        dumped.update(model_extra)
+
+    return {
+        key: value
+        for key, value in dumped.items()
+        if key not in _CANONICAL_TOOL_CALL_FIELDS
+    }
+
+
+def _gemini_reasoning_effort(cfg: Config, spec: AgentCallSpec) -> str | None:
+    """Resolve optional Gemini thinking level for one routed agent call."""
+    gemini_cfg = cfg.llm.gemini
+    route_key = (
+        f"{spec.route.agent}.{spec.route.mode}"
+        if spec.route.mode
+        else spec.route.agent
+    )
+    level = gemini_cfg.thinking_by_mode.get(route_key, gemini_cfg.thinking_level)
+    return None if level == "default" else level
+
 
 def _is_reasoning_model(model: str) -> bool:
     m = model.lower()

--- a/co_scientist/llm/provider.py
+++ b/co_scientist/llm/provider.py
@@ -16,7 +16,11 @@ Concretely:
 Provider-specific features:
 - cache_control: honored only on Anthropic. Stripped before sending elsewhere.
 - thinking / extended reasoning: Anthropic for Claude opus; on OpenAI we
-  translate to `reasoning_effort` for o-series models, else drop.
+  translate to `reasoning_effort` for o-series models. The named Gemini
+  provider accepts optional semantic levels under `[llm.gemini]`.
+- provider-owned tool-call fields: retained as opaque metadata by the
+  OpenAI-compatible adapter; only provider-documented request fields are
+  replayed (currently Gemini's thought-signature envelope).
 - batch API: Anthropic only; the BatchPool still talks to Anthropic directly.
 
 Users select a provider in `[llm] provider = "..."` and per-agent models in
@@ -154,6 +158,7 @@ def get_provider(
         return OpenAIClient(
             cfg, db=db, budget=budget, retry_policy=retry_policy,
             compat_mode=(name == "openai_compatible"),
+            provider_name=name,
         )
 
     # Named OpenAI-compat preset (openrouter, gemini, groq, together, ...).
@@ -171,6 +176,7 @@ def get_provider(
             cfg,
             db=db, budget=budget, retry_policy=retry_policy,
             compat_mode=True,
+            provider_name=name,
             preset_base_url=preset["base_url"],   # type: ignore[arg-type]
             preset_api_key_env=preset["api_key_env"],  # type: ignore[arg-type]
             default_headers=default_headers,

--- a/co_scientist/llm/tool_loop.py
+++ b/co_scientist/llm/tool_loop.py
@@ -277,14 +277,16 @@ def _content_to_dicts(content) -> list[dict[str, Any]]:
         if t == "text":
             out.append({"type": "text", "text": getattr(b, "text", "")})
         elif t == "tool_use":
-            out.append(
-                {
-                    "type": "tool_use",
-                    "id": getattr(b, "id", ""),
-                    "name": getattr(b, "name", ""),
-                    "input": getattr(b, "input", {}),
-                }
-            )
+            d = {
+                "type": "tool_use",
+                "id": getattr(b, "id", ""),
+                "name": getattr(b, "name", ""),
+                "input": getattr(b, "input", {}),
+            }
+            provider_fields = getattr(b, "provider_fields", None)
+            if isinstance(provider_fields, dict) and provider_fields:
+                d["provider_fields"] = provider_fields
+            out.append(d)
         elif t == "thinking":
             d: dict[str, Any] = {"type": "thinking", "thinking": getattr(b, "thinking", "")}
             sig = getattr(b, "signature", None)

--- a/co_scientist/tests/unit/test_provider.py
+++ b/co_scientist/tests/unit/test_provider.py
@@ -16,15 +16,18 @@ import pytest
 from co_scientist.config import Config
 from co_scientist.llm.anthropic_client import AgentCallSpec, CachedBlock, CallContext
 from co_scientist.llm.openai_client import (
+    _TOOL_CALL_REPLAY_FIELDS_BY_PROVIDER,
     OpenAIClient,
     _adapt_response,
     _budget_to_effort,
     _build_openai_request,
     _is_reasoning_model,
+    _provider_fields_from_tool_call,
     _translate_anthropic_message,
 )
 from co_scientist.llm.provider import KNOWN_PROVIDERS, get_provider
 from co_scientist.llm.routing import ModelRoute
+from co_scientist.llm.tool_loop import _content_to_dicts
 
 
 def _route(model: str = "gpt-5", thinking: int = 0) -> ModelRoute:
@@ -306,6 +309,88 @@ def test_translate_assistant_tool_use_to_openai_tool_calls() -> None:
     assert tc["id"] == "call_1"
 
 
+def test_translate_does_not_replay_provider_fields_by_default() -> None:
+    msg = {
+        "role": "assistant",
+        "content": [{
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "search",
+            "input": {"q": "abc"},
+            "provider_fields": {
+                "extra_content": {"google": {"thought_signature": "sig"}},
+                "index": 0,
+                "response_only": True,
+            },
+        }],
+    }
+
+    tool_call = _translate_anthropic_message(msg)[0]["tool_calls"][0]
+
+    assert set(tool_call) == {"id", "type", "function"}
+
+
+def test_translate_replays_only_explicitly_allowed_provider_fields() -> None:
+    extra_content = {"google": {"thought_signature": "sig"}}
+    msg = {
+        "role": "assistant",
+        "content": [{
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "search",
+            "input": {"q": "abc"},
+            "provider_fields": {
+                "extra_content": extra_content,
+                "index": 0,
+                "response_only": True,
+                "id": "spoofed-id",
+                "type": "spoofed-type",
+                "function": {"name": "spoofed-function"},
+            },
+        }],
+    }
+
+    tool_call = _translate_anthropic_message(
+        msg,
+        tool_call_replay_fields=frozenset({"extra_content"}),
+    )[0]["tool_calls"][0]
+
+    assert tool_call["extra_content"] == extra_content
+    assert "index" not in tool_call
+    assert "response_only" not in tool_call
+    assert tool_call["id"] == "call_1"
+    assert tool_call["type"] == "function"
+    assert tool_call["function"]["name"] == "search"
+
+
+@pytest.mark.parametrize("extra_content", [None, {}, [], "not-an-envelope"])
+def test_translate_drops_malformed_extra_content(extra_content) -> None:
+    msg = {
+        "role": "assistant",
+        "content": [{
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "search",
+            "input": {},
+            "provider_fields": {"extra_content": extra_content},
+        }],
+    }
+
+    tool_call = _translate_anthropic_message(
+        msg,
+        tool_call_replay_fields=frozenset({"extra_content"}),
+    )[0]["tool_calls"][0]
+
+    assert "extra_content" not in tool_call
+
+
+def test_only_named_gemini_providers_enable_tool_call_metadata_replay() -> None:
+    assert {
+        "gemini": frozenset({"extra_content"}),
+        "google": frozenset({"extra_content"}),
+    } == _TOOL_CALL_REPLAY_FIELDS_BY_PROVIDER
+
+
 def test_translate_user_tool_result_to_openai_tool_message() -> None:
     msg = {
         "role": "user",
@@ -356,11 +441,13 @@ def _fake_openai_response(*, text: str = "", tool_calls: list[dict] | None = Non
     """Build a SimpleNamespace that quacks like an openai ChatCompletion."""
     tcs = []
     for tc in (tool_calls or []):
-        tcs.append(SimpleNamespace(
+        tool_call_fields = dict(
             id=tc["id"],
             type="function",
             function=SimpleNamespace(name=tc["name"], arguments=tc["arguments"]),
-        ))
+        )
+        tool_call_fields.update(tc.get("provider_fields", {}))
+        tcs.append(SimpleNamespace(**tool_call_fields))
     msg = SimpleNamespace(content=text or None, tool_calls=tcs or None)
     choice = SimpleNamespace(message=msg, finish_reason=finish)
     usage = SimpleNamespace(prompt_tokens=in_tok, completion_tokens=out_tok)
@@ -389,6 +476,95 @@ def test_adapt_response_tool_call() -> None:
     assert tu.name == "search"
     assert tu.input == {"q": "foo"}
     assert tu.id == "call_42"
+
+
+def test_adapt_response_retains_noncanonical_tool_call_fields() -> None:
+    extra_content = {"google": {"thought_signature": "sig"}}
+    raw = _fake_openai_response(
+        tool_calls=[{
+            "id": "call_42",
+            "name": "search",
+            "arguments": '{"q": "foo"}',
+            "provider_fields": {
+                "extra_content": extra_content,
+                "index": 0,
+                "response_only": True,
+            },
+        }],
+        finish="tool_calls",
+    )
+
+    tool_use = _adapt_response(raw, "gemini-3.5-flash").content[0]
+
+    assert tool_use.provider_fields == {
+        "extra_content": extra_content,
+        "index": 0,
+        "response_only": True,
+    }
+
+
+def test_provider_field_capture_merges_pydantic_model_extra() -> None:
+    class ToolCall:
+        def __init__(self) -> None:
+            self.model_extra = {
+                "extra_content": {"google": {"thought_signature": "sig"}},
+                "index": 0,
+            }
+
+        def model_dump(self):
+            return {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+
+    tool_call = ToolCall()
+    assert _provider_fields_from_tool_call(tool_call) == tool_call.model_extra
+
+
+def test_tool_call_metadata_policy_applies_across_the_continuation_pipeline() -> None:
+    extra_content = {"google": {"thought_signature": "opaque-signature"}}
+    raw = _fake_openai_response(
+        tool_calls=[{
+            "id": "call_42",
+            "name": "search",
+            "arguments": '{"q": "foo"}',
+            "provider_fields": {
+                "extra_content": extra_content,
+                "index": 0,
+            },
+        }],
+        finish="tool_calls",
+    )
+    assistant_blocks = _content_to_dicts(
+        _adapt_response(raw, "gemini-3.5-flash").content
+    )
+    spec = AgentCallSpec(
+        route=_route(model="gemini-3.5-flash"),
+        user_blocks=[CachedBlock("Search for foo.")],
+        extra_messages=[
+            {"role": "assistant", "content": assistant_blocks},
+            {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "call_42",
+                    "content": "result",
+                }],
+            },
+        ],
+    )
+
+    strict_tool_call = _build_openai_request(spec)["messages"][1]["tool_calls"][0]
+    gemini_tool_call = _build_openai_request(
+        spec,
+        tool_call_replay_fields=_TOOL_CALL_REPLAY_FIELDS_BY_PROVIDER["gemini"],
+    )["messages"][1]["tool_calls"][0]
+
+    assert "extra_content" not in strict_tool_call
+    assert "index" not in strict_tool_call
+    assert gemini_tool_call["extra_content"] == extra_content
+    assert "index" not in gemini_tool_call
 
 
 def test_adapt_response_handles_malformed_tool_args() -> None:

--- a/config/default.toml
+++ b/config/default.toml
@@ -154,8 +154,8 @@ classifier_warn_categories = ["dual_use_bio"]
 #                  "anthropic/claude-3.5-sonnet", "openai/gpt-5",
 #                  "google/gemini-2.5-pro", "meta-llama/llama-3.3-70b".
 #   "gemini"     — Google Gemini via OpenAI-compat endpoint. Set
-#                  GEMINI_API_KEY. Models: "gemini-2.5-pro",
-#                  "gemini-2.5-flash", "gemini-1.5-pro".
+#                  GEMINI_API_KEY. Models: "gemini-3.5-flash-lite",
+#                  "gemini-3.5-flash", "gemini-2.5-pro".
 #   "groq"       — Groq (fast Llama / Mixtral). Set GROQ_API_KEY.
 #   "together"   — Together AI. Set TOGETHER_API_KEY.
 #   "mistral"    — Mistral la-plateforme. Set MISTRAL_API_KEY.
@@ -172,6 +172,26 @@ provider = "anthropic"
 # overrides the preset's base_url (rarely needed).
 [llm.openai]
 # base_url = ""
+
+# Gemini reasoning control for provider = "gemini" / "google".
+# "default" omits reasoning_effort and uses the selected model's default.
+# For multi-step agent/tool work, "medium" is a sensible starting point.
+[llm.gemini]
+thinking_level = "default"  # default | minimal | low | medium | high
+
+# Optional per-mode overrides. Keys match agent routing modes.
+# [llm.gemini.thinking_by_mode]
+# "parse_goal" = "minimal"
+# "generation.literature" = "medium"
+# "reflection.full" = "high"
+# "ranking.pairwise" = "medium"
+# "ranking.debate" = "high"
+# "evolution.combine" = "high"
+# "evolution.out_of_box" = "high"
+# "evolution.feasibility" = "medium"
+# "evolution.simplify" = "medium"
+# "metareview.system" = "medium"
+# "metareview.final" = "high"
 
 # OpenRouter attribution (optional; for catalog ranking).
 [llm.openrouter]


### PR DESCRIPTION
## Summary

- Preserve Gemini 3 thought signatures across sequential and parallel tool calls.
- Add optional, configurable Gemini reasoning levels for the named `gemini` and `google` providers.
- Retain unknown provider metadata internally while replaying only Gemini's documented `extra_content` tool-call envelope.
- Keep OpenAI and other OpenAI-compatible endpoints strict by default.
- Add regression coverage for metadata capture, provider-aware replay, malformed envelopes, canonical-field protection, and the complete continuation pipeline.

## Motivation

Gemini 3's OpenAI-compatible API attaches a required thought signature under `extra_content.google.thought_signature`. Multi-step tool calls can fail if that signature is not returned with the corresponding assistant tool call.

Blindly replaying every unknown response field is also unsafe because strict OpenAI-compatible endpoints may reject response-only fields. This change separates generic metadata retention from outbound replay and uses an explicit provider allowlist.

## Testing

- `python -m pytest -q`
  - 231 passed
- `python3 -m ruff check co_scientist/llm/openai_client.py co_scientist/llm/provider.py co_scientist/tests/unit/test_provider.py`
  - Passed
- `python -m ruff check .`
  - Currently reports 9 unrelated `RUF001` findings in `scripts/build_bench_report.py`, which is not modified by this PR.
 